### PR TITLE
Adding support to custom ports for alb_subraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module "graphos_aws" {
 * The ALB must be in the same AWS Region as the lattice services.
 * The ALB must be an **internal** load balancer.
 * The ALB must have a listener configured to listen on `HTTP` on port `80` by default or whatever value you provide to `alb_port`.
-* The security group associated with the ALB must allow TCP traffic on port `80` (or you must set `alb_port``) from the [VPC Lattice prefix list](https://docs.aws.amazon.com/vpc-lattice/latest/ug/security-groups.html).
+* The security group associated with the ALB must allow TCP traffic on port `80` (or you must set `alb_port`) from the [VPC Lattice prefix list](https://docs.aws.amazon.com/vpc-lattice/latest/ug/security-groups.html).
 * The `vpc_id` must be the same as the VPC where the ALB is deployed.
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ This module will create:
 
 ## Usage
 
-```
+```hcl
 module "graphos_aws" {
   source = "github.com/apollographql/terraform-graphos-aws"
 
   alb_subgraphs = {
     "some-subgraph" = {
-      alb_arn = "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/some-app-name/1234567890abcdef"
-      vpc_id  = "vpc-1234567890abcdef0"
+      alb_arn  = "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/some-app-name/1234567890abcdef" # Arn for the internal ALB
+      vpc_id   = "vpc-1234567890abcdef0" # VPC the load balancer is deployed to
+      alb_port = 80 # Or custom port 
     }
   }
 
@@ -61,6 +62,7 @@ module "graphos_aws" {
 * `alb_subgraphs`: map of subgraph names to ALB configuration
   * `alb_arn`: ARN of the Application Load Balancer
   * `vpc_id`: ID of the VPC where the Application Load Balancer is deployed
+  * `alb_port`: Port the ALB receives traffic through (defaults to 80)
 * `lambda_subgraphs`: map of subgraph names to Lambda functions
   * `lambda_function_arn`: ARN of the Lambda function
 
@@ -81,8 +83,8 @@ module "graphos_aws" {
 
 * The ALB must be in the same AWS Region as the lattice services.
 * The ALB must be an **internal** load balancer.
-* The ALB must have a listener configured to listen on `HTTP:80`.
-* The security group associated with the ALB must allow TCP traffic on port 80 from the [VPC Lattice prefix list](https://docs.aws.amazon.com/vpc-lattice/latest/ug/security-groups.html).
+* The ALB must have a listener configured to listen on `HTTP` on port `80` by default or whatever value you provide to `alb_port`.
+* The security group associated with the ALB must allow TCP traffic on port `80` (or you must set `alb_port``) from the [VPC Lattice prefix list](https://docs.aws.amazon.com/vpc-lattice/latest/ug/security-groups.html).
 * The `vpc_id` must be the same as the VPC where the ALB is deployed.
 
 ## Maintainers

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ module "alb_subgraphs" {
 
   vpc_id  = each.value.vpc_id
   alb_arn = each.value.alb_arn
+  alb_port = each.value.alb_port
 
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,9 @@ variable "tags" {
 variable "alb_subgraphs" {
   description = "Mapping of name to Application Load Balancers"
   type = map(object({
-    alb_arn = string
-    vpc_id  = string
+    alb_arn  = string
+    vpc_id   = string
+    alb_port = number
   }))
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "alb_subgraphs" {
   type = map(object({
     alb_arn  = string
     vpc_id   = string
-    alb_port = number
+    alb_port = optional(number, 80)
   }))
 }
 


### PR DESCRIPTION
### Background

👋 Hello! Recently onboarded into the dedicated experience and I tried playing with the graphos integration today. However, after battling with things for a bit, I figured out that our infrastructure needed to change considerably in order for the communication to happen on port 80 by default. That lead me to come look at the source code and see if it wouldn't be possible to pass a custom port number where the ALB expects communication.

To my surprise, the underlying module already supports a custom port, but `alb_subgraphs` does not receive that value in it's definition.

### Changes
- Tweak README to mention that `alb_subgraphs` can take a `alb_port` variable that allows one to customize the communication port.
- Added `hcl` markdown to hcl block.
- Changed README lingo around port 80 being required
- Updated `alb_subgraphs` to receive a `alb_port` argument that is passed down to `aws_vpclattice_target_group` and `aws_vpclattice_target_group_attachment`.
