### PR TITLE
feat: add ability to restrict traffic based on principal tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ module "graphos_aws" {
       lambda_function_arn = "arn:aws:lambda:eu-west-1:012346789012:function:test-function"
     }
   }
+
+  apollo_account_ids = ["my_account_id"]
+  apollo_graph_refs  = ["my-graph@my-variant"]
 }
 ```
 
@@ -65,6 +68,8 @@ module "graphos_aws" {
   * `alb_port`: Port the ALB receives traffic through (defaults to 80)
 * `lambda_subgraphs`: map of subgraph names to Lambda functions
   * `lambda_function_arn`: ARN of the Lambda function
+* `apollo_account_ids`: List of unique identifiers to your Apollo accounts, to only allow traffic from Cloud Routers in your Apollo account only as an extra layer of security. This value is not the same as the Apollo Account ID in your Organization settings page.
+* `apollo_graph_refs`: List of graph variant references, to only allow traffic from Cloud Routers matching those specific graph variant references.
 
 ## Outputs
 

--- a/modules/alb-subgraphs/main.tf
+++ b/modules/alb-subgraphs/main.tf
@@ -14,6 +14,7 @@ module "lattice" {
 
   prefix                         = var.prefix
   tags                           = var.tags
+  principal_tags                 = var.principal_tags
   graphos_organizational_unit_id = var.graphos_organizational_unit_id
   graphos_account_id             = var.graphos_account_id
 

--- a/modules/alb-subgraphs/variables.tf
+++ b/modules/alb-subgraphs/variables.tf
@@ -29,6 +29,12 @@ variable "vpc_id" {
   }
 }
 
+variable "principal_tags" {
+  description = "Restrict content based on the values of these tags"
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "alb_arn" {
   description = "ARN of the load balancer"
   type        = string

--- a/modules/lambda-subgraphs/main.tf
+++ b/modules/lambda-subgraphs/main.tf
@@ -14,6 +14,7 @@ module "lattice" {
 
   prefix                         = var.prefix
   tags                           = var.tags
+  principal_tags                 = var.principal_tags
   graphos_organizational_unit_id = var.graphos_organizational_unit_id
   graphos_account_id             = var.graphos_account_id
 }

--- a/modules/lambda-subgraphs/variables.tf
+++ b/modules/lambda-subgraphs/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "principal_tags" {
+  description = "Restrict content based on the values of these tags"
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "graphos_organizational_unit_id" {
   type    = string
   default = "ou-leyb-fvqz35yo"

--- a/modules/lattice-service/main.tf
+++ b/modules/lattice-service/main.tf
@@ -54,6 +54,17 @@ data "aws_iam_policy_document" "graphos_policy" {
       variable = "aws:PrincipalOrgPaths"
       values   = ["o-9vaxczew6u/*/ou-leyb-l9pccq2t/${var.graphos_organizational_unit_id}/*"]
     }
+
+    // Restrict based on tags on the principal
+    dynamic "condition" {
+      for_each = var.principal_tags
+
+      content {
+        test     = "StringEquals"
+        variable = "aws:PrincipalTag/${condition.key}"
+        values   = condition.value
+      }
+    }
   }
 }
 

--- a/modules/lattice-service/variables.tf
+++ b/modules/lattice-service/variables.tf
@@ -16,6 +16,12 @@ variable "default_target_group" {
   default     = ""
 }
 
+variable "principal_tags" {
+  description = "Restrict content based on the values of these tags"
+  type        = map(list(string))
+  default     = {}
+}
+
 variable "graphos_organizational_unit_id" {
   type    = string
   default = "ou-leyb-fvqz35yo"

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,18 @@ variable "lambda_subgraphs" {
   default = {}
 }
 
+variable "apollo_account_ids" {
+  description = "Restrict traffic based on a unique identifier per account"
+  type        = list(string)
+  default     = []
+}
+
+variable "apollo_graph_refs" {
+  description = "Restrict traffic based on Cloud Router graph variant identifiers (e.g. my-graph@my-variant)"
+  type        = list(string)
+  default     = []
+}
+
 variable "graphos_organizational_unit_id" {
   type    = string
   default = "ou-leyb-fvqz35yo"


### PR DESCRIPTION
Add the ability to restrict traffic to your AWS VPC Lattice Services based on specific tag values.

At the moment, the following values are supported:

* `Apollo:accountId`: Unique identifier for your Apollo Organization account. Please note it is not the same as the one you can configure in the Apollo GraphOS Studio UI.
* `Apollo:graphRef`: Unique identifier for your Cloud Routers (e.g. `my-graph@my-variant`).